### PR TITLE
Fixed example of using setErrors mutator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const MyForm: FunctionComponent<IMyFormProps> = ({ submit }) => {
     return (
         <Form
             onSubmit={submit}
-            mutators={[ setErrors ]}
+            mutators={{ setErrors }}
         >
             {({ handleSubmit }) => {
                 return (


### PR DESCRIPTION
mutators should be passed as object, not as array.